### PR TITLE
fix google meet link in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Link to the Discord: [https://discord.gg/e5pYxM3D](https://discord.gg/e5pYxM3D)
 
 | Session    |              Time                | Link to join (or recording)                                  | Slides                           | Take-Home Exercises          |
 | --------   | -------                          |  ----                                                        |         -----                    |        -----                 |
-| 1          | 3:30PM US Pacific, 2/21/2024     | [Google Meet link](meet.google.com/tdd-brrt-gtp)             | To come                          |  To come                     |
+| 1          | 3:30PM US Pacific, 2/21/2024     | [Google Meet link](https://meet.google.com/tdd-brrt-gtp)     | To come                          |  To come                     |
 | 2          | 3:30PM US Pacific, 2/28/2024     |                                                              |                                  |                              |
 
 About me:


### PR DESCRIPTION
Without the `https://` it went to https://github.com/rwitten/HighPerfLLMs2024/blob/main/meet.google.com/tdd-brrt-gtp